### PR TITLE
Lazy load menu, chops 30k from the main bundle.

### DIFF
--- a/src/app/containers/application/Application.js
+++ b/src/app/containers/application/Application.js
@@ -3,10 +3,24 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import LoadingBar from '../../components/loading-bar/LoadingBar';
-import Menu from '../menu/Menu';
 import { canSmoothScroll } from './util/smoothScroll';
 
+let Menu; // Menu component will be lazy loaded here
+
 class Application extends Component {
+    constructor(props) {
+        super(props);
+        this.state = { isMenuLoaded: false };
+    }
+
+    componentDidMount() {
+        // Lazy load the Menu because it's too heavy due to snapsvg
+        require.ensure([], (require) => {
+            Menu = require('../menu/Menu').default;
+            this.setState({ isMenuLoaded: true });  // eslint-disable-line react/no-set-state
+        }, 'menu');
+    }
+
     render() {
         return (
             <div id="application">
@@ -15,7 +29,7 @@ class Application extends Component {
                 </div>
 
                 <div id="menu">
-                    <Menu />
+                    { this.state.isMenuLoaded ? <Menu /> : '' }
                 </div>
 
                 <div id="page">

--- a/src/shared/containers/header/Header.css
+++ b/src/shared/containers/header/Header.css
@@ -13,6 +13,9 @@
     vertical-align: middle;
 }
 
+/* Logo
+   ========================================================================== */
+
 .header-component .logo {
     width: 20px;
     padding-left: 20px;
@@ -42,28 +45,20 @@
     text-decoration: none;
 }
 
+/* Search box tweeks
+   ========================================================================== */
+
 .header-component .search-box .search-box-component {
     max-width: 700px;
 }
+
+/* Right side actions
+   ========================================================================== */
 
 .header-component .other-actions {
     width: 160px;
     text-align: right;
     user-select: none;
-}
-
-.header-component .other-actions .toggle-menu {
-    margin-right: 17px;  /* Should be 20px but icon is centered */
-    display: inline-block;
-    vertical-align: middle;
-}
-
-.header-component .other-actions .toggle-menu i {
-    cursor: pointer;
-}
-
-.header-component .other-actions .toggle-menu:hover {
-    color: #1dd09b;
 }
 
 .header-component .other-actions .social-link {
@@ -76,6 +71,28 @@
 
 .header-component .other-actions .social-link:hover {
     fill: #1dd09b;
+}
+
+.header-component .other-actions .toggle-menu {
+    margin-right: 17px;  /* Should be 20px but icon is centered */
+    display: inline-block;
+    vertical-align: middle;
+    opacity: 0.3;
+    pointer-events: none;
+    transition: opacity 0.2s linear;
+}
+
+.header-component .other-actions .toggle-menu:hover {
+    color: #1dd09b;
+}
+
+.is-menu-mounted .header-component .other-actions .toggle-menu {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.header-component .other-actions .toggle-menu i {
+    cursor: pointer;
 }
 
 /* Utility classes to be used by several pages


### PR DESCRIPTION
Menu has a cool SVG animation but it uses the heavy snapsvg library. By lazy loading the menu, we can save ~30kbs from the initial page load.

@atduarte do you think this is worth the extra complexity?

Ignore the CSS diff, most of the lines are just declarations order.
