### PR TITLE
Update LoadingBar.js

### DIFF
--- a/src/app/components/loading-bar/LoadingBar.js
+++ b/src/app/components/loading-bar/LoadingBar.js
@@ -7,7 +7,7 @@ import shallowCompare from 'react-addons-shallow-compare';
 const autoUpdateInterval = 250;
 const firstPercentage = 0.55;
 
-export default class LoadingBar extends Component {
+class LoadingBar extends Component {
     constructor(props) {
         super(props);
         this.state = { percentage: 0 };


### PR DESCRIPTION
> Module build failed: SyntaxError: Only one default export allowed per module.
