### PR TITLE
Update overlay text of npmjs.com link

### DIFF
--- a/src/routes/search/components/ResultsListItem.js
+++ b/src/routes/search/components/ResultsListItem.js
@@ -103,7 +103,7 @@ class ResultsListItem extends Component {
                     </a>
                 </Tooltip>
 
-                <Tooltip placement="top" trigger={ ['hover'] } overlay="View this package in npmjs.org">
+                <Tooltip placement="top" trigger={ ['hover'] } overlay="View this package in npmjs.com">
                     <a className="npm-link" href={ this.props.package.links.npm } target="_blank">
                         <SvgIcon id={ SvgIcon.npm } />
                     </a>

--- a/src/routes/search/components/ResultsListItem.js
+++ b/src/routes/search/components/ResultsListItem.js
@@ -103,7 +103,7 @@ class ResultsListItem extends Component {
                     </a>
                 </Tooltip>
 
-                <Tooltip placement="top" trigger={ ['hover'] } overlay="View this package in npmjs.com">
+                <Tooltip placement="top" trigger={ ['hover'] } overlay="View this package on npmjs.com">
                     <a className="npm-link" href={ this.props.package.links.npm } target="_blank">
                         <SvgIcon id={ SvgIcon.npm } />
                     </a>


### PR DESCRIPTION
- The link itself points to npmjs.com (instead of npmjs.org), so I updated the text accordingly.
- “on npmjs.com” [sounds better](http://english.stackexchange.com/q/3491) and is [used more widely](http://english.stackexchange.com/a/82869) than “in npmjs.com”.