### PR TITLE
set overflow to auto

### DIFF
--- a/src/app/styles/layout.css
+++ b/src/app/styles/layout.css
@@ -11,7 +11,7 @@ body {
 
 body {
     position: relative;  /* Necessary so that descendants with 100% actually target body width */
-    overflow-y: scroll;  /* Prevent screen from "dancing" when going from a page to another */
+    overflow-y: auto;  /* Prevent screen from "dancing" when going from a page to another */
 }
 
 * {


### PR DESCRIPTION
Currently the space for the right scrollbar is always visible.

This is not a great or the right behavior for good webdesign.
It should be set to auto.