### PR TITLE
tests: use npm ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: node_js
 node_js:
   - "4"
   - "6"
+before_install:
+  - npm i -g npm@latest
+install:
+  - npm ci


### PR DESCRIPTION
`npm ci` is much faster and is meant for CI. This PR is meant for evaluating the new ci command and testig the performance and compare the logs of Travis CI.

https://docs.npmjs.com/cli/ci
http://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable