### PR TITLE
Removed max-width from version class

### DIFF
--- a/src/routes/search/components/ResultsListItem.css
+++ b/src/routes/search/components/ResultsListItem.css
@@ -20,7 +20,6 @@
 }
 
 .page-search .results-list-item .headline .version {
-    max-width: 55px;
     margin-left: 7px;
     color: #858585;
     font-size: 12px;


### PR DESCRIPTION
Hi, i like the project, it was just a little bit annoying to check some versions that are truncated by the text-overflow ellipsis, which usually happens on beta or alpha version.

eg.: `1.0.0-beta.20` truncated to `1.0.0-b...`

![screen shot 2018-06-20 at 17 41 27](https://user-images.githubusercontent.com/5366959/41683147-36fe3efa-74b0-11e8-93a4-ea417b8e0fee.png)
