### PR TITLE
Fix gravatar image alt attribute, #225, #214

### DIFF
--- a/src/routes/about/containers/About.js
+++ b/src/routes/about/containers/About.js
@@ -193,7 +193,7 @@ class About extends Component {
                             <h1>Authors</h1>
                             <div className="authors-list">
                                 <div className="author">
-                                    <Gravatar size={ 130 } email="andremiguelcruz@msn.com" className="avatar" />
+                                    <Gravatar size={ 130 } alt="avatar" email="andremiguelcruz@msn.com" className="avatar" />
                                     <div className="name">André Cruz</div>
                                     <div className="links">
                                         <a className="social-link" href="https://twitter.com/satazor" target="_blank">
@@ -206,7 +206,7 @@ class About extends Component {
                                 </div>
 
                                 <div className="author">
-                                    <Gravatar size={ 130 } email="mail@andreduarte.net" className="avatar" />
+                                    <Gravatar size={ 130 } alt="avatar" email="mail@andreduarte.net" className="avatar" />
                                     <div className="name">André Duarte</div>
                                     <div className="links">
                                         <a className="social-link" href="https://twitter.com/atduarte" target="_blank">

--- a/src/routes/search/components/ResultsListItem.js
+++ b/src/routes/search/components/ResultsListItem.js
@@ -87,7 +87,7 @@ class ResultsListItem extends Component {
                 { hasPublisher ? <a href={ `https://npmjs.com/~${encodeURIComponent(this.props.package.publisher.username)}` }
                     target="_blank" className="publisher-name">{ this.props.package.publisher.username }</a> : '' }
                 { hasPublisher ? <span className="publisher-avatar">
-                    <Gravatar size={ 20 } email={ this.props.package.publisher.email || 'n/a' }
+                    <Gravatar alt="avatar" size={ 20 } email={ this.props.package.publisher.email || 'n/a' }
                         onLoad={ (e) => this._onGravatarLoad(e) } /></span> : '' }
             </div>
         );


### PR DESCRIPTION
Fixes #225, #214

We are still using good old `react-gravatar` component.
I have override image the alt attribute.
I have  fixed "about" page avatar as well.

Thanks.